### PR TITLE
feat: #5 共通エラーハンドラによるエラーログ出力機能の追加

### DIFF
--- a/backend/handlers/health.go
+++ b/backend/handlers/health.go
@@ -2,13 +2,14 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"go-movie-explorer/models"
 )
 
 // HealthHandler はヘルスチェックエンドポイントのハンドラー
-func HealthHandler(w http.ResponseWriter, r *http.Request) {
+func HealthHandler(w http.ResponseWriter, r *http.Request) error {
 	// JSONレスポンス用ヘッダー設定
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -17,5 +18,8 @@ func HealthHandler(w http.ResponseWriter, r *http.Request) {
 	response := models.NewHealthResponse()
 
 	// JSON形式でレスポンス返却
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		return fmt.Errorf("failed to encode health response: %w", err)
+	}
+	return nil
 }

--- a/backend/handlers/movies.go
+++ b/backend/handlers/movies.go
@@ -1,3 +1,50 @@
 package handlers
 
-// 作成予定
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"go-movie-explorer/models"
+)
+
+// MoviesHandler handles /api/movies requests
+func MoviesHandler(w http.ResponseWriter, r *http.Request) error {
+	w.Header().Set("Content-Type", "application/json")
+
+	// クエリパラメータ取得
+	pageStr := r.URL.Query().Get("page")
+	limitStr := r.URL.Query().Get("limit")
+	page := 1
+	if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
+		page = p
+	}
+	if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+		_ = l // 仮実装なので未使用
+	}
+
+	// サービス層でTMDB APIから映画一覧を取得（仮実装）
+	// TODO: services.GetMoviesFromTMDB(page, limit) などに置き換え
+	resp := models.MoviesResponse{
+		Page:         page,
+		TotalPages:   1,
+		TotalResults: 1,
+		Movies: []models.Movie{
+			{
+				ID:          1,
+				Title:       "サンプル映画",
+				Overview:    "これはサンプルです",
+				ReleaseDate: "2025-01-01",
+				PosterPath:  "/sample.jpg",
+				VoteAverage: 8.5,
+				Popularity:  123.4,
+			},
+		},
+	}
+
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		return fmt.Errorf("failed to encode response: %w", err)
+	}
+	return nil
+}

--- a/backend/logs/server.log
+++ b/backend/logs/server.log
@@ -1,1 +1,0 @@
-2025/06/27 21:56:02 Server listening on port :8080

--- a/backend/main.go
+++ b/backend/main.go
@@ -7,6 +7,9 @@ import (
 	"os"
 
 	"go-movie-explorer/handlers"
+	"go-movie-explorer/middleware"
+
+	"github.com/joho/godotenv"
 )
 
 // ログ付きハンドラーラッパー
@@ -18,6 +21,14 @@ func logHandler(handler http.HandlerFunc) http.HandlerFunc {
 }
 
 func main() {
+	// .env読み込み
+	_ = godotenv.Load(".env")
+
+	// logsディレクトリ自動作成
+	if err := os.MkdirAll("logs", 0755); err != nil {
+		log.Fatalf("logsディレクトリの作成に失敗: %v", err)
+	}
+
 	// ログファイル設定
 	logFile, err := os.OpenFile("logs/server.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
@@ -26,12 +37,22 @@ func main() {
 	defer logFile.Close()
 	log.SetOutput(logFile)
 
-	// ルーティング設定（ログ付き）
-	http.HandleFunc("/health", logHandler(handlers.HealthHandler))
+	// 環境変数取得
+	port := os.Getenv("PORT")
+	if port == "" {
+		log.Fatal("PORTが設定されていません")
+	}
+	port = ":" + port
 
-	// サーバー設定
-	// TODO: 後ほど環境変数で設定できるようにする
-	port := ":8080"
+	tmdbApiKey := os.Getenv("TMDB_API_KEY")
+	if tmdbApiKey == "" {
+		log.Fatal("TMDB_API_KEYが設定されていません")
+	}
+
+	// ルーティング設定（ログ付き）
+	http.HandleFunc("/health", logHandler(middleware.ErrorHandler(handlers.HealthHandler)))
+	http.HandleFunc("/api/movies", logHandler(middleware.ErrorHandler(handlers.MoviesHandler)))
+
 	fmt.Printf("Server starting on http://localhost%s\n", port)
 	log.Printf("Server listening on port %s", port)
 

--- a/backend/middleware/error_handler.go
+++ b/backend/middleware/error_handler.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+)
+
+type AppHandler func(http.ResponseWriter, *http.Request) error
+
+func ErrorHandler(h AppHandler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := h(w, r); err != nil {
+			log.Printf("handler error: %v", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}
+}


### PR DESCRIPTION
# 概要
- 全てのハンドラーで発生したエラーを共通エラーハンドラでログファイル（logs/server.log）に記録する仕組みを追加

## 変更点
- middleware/error_handler.go: 共通エラーハンドラの実装
- 各ハンドラーの返り値をerror型に変更
- main.goでErrorHandlerをルーティングに適用
- logs/ディレクトリの自動作成処理を追加

## 完了定義
- ハンドラーでエラーが発生した場合、logs/server.logに記録されること
- 既存のAPIが正常に動作すること

Why: 全てのハンドラーで発生したエラーをログファイルに記録し、運用保守性を高めるため