### PR TITLE
refactor: APIクライアントをclass型から関数型に変更

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -2,63 +2,56 @@ import type { MoviesResponse, MovieDetail, GenreMovieListResponse, APIError } fr
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
 
-class APIClient {
-  private baseURL: string;
-
-  constructor(baseURL: string = API_BASE_URL) {
-    this.baseURL = baseURL;
-  }
-
-  private async request<T>(
-    endpoint: string,
-    options: RequestInit = {}
-  ): Promise<T> {
-    const url = `${this.baseURL}${endpoint}`;
-    
-    try {
-      const response = await fetch(url, {
-        headers: {
-          'Content-Type': 'application/json',
-          ...options.headers,
-        },
-        ...options,
-      });
-
-      if (!response.ok) {
-        const errorData: APIError = await response.json();
-        throw new Error(errorData.message || `HTTP ${response.status}`);
-      }
-
-      return await response.json();
-    } catch (error) {
-      if (error instanceof Error) {
-        throw error;
-      }
-      throw new Error('Network error occurred');
-    }
-  }
-
-  async getMovies(page: number = 1): Promise<MoviesResponse> {
-    return this.request<MoviesResponse>(`/api/movies?page=${page}`);
-  }
-
-  async getMovieDetail(id: number): Promise<MovieDetail> {
-    return this.request<MovieDetail>(`/api/movie/${id}`);
-  }
-
-  async searchMovies(query: string, page: number = 1): Promise<MoviesResponse> {
-    const encodedQuery = encodeURIComponent(query);
-    return this.request<MoviesResponse>(`/api/movies/search?query=${encodedQuery}&page=${page}`);
-  }
-
-  async getMoviesByGenre(genreId: number, page: number = 1): Promise<GenreMovieListResponse> {
-    return this.request<GenreMovieListResponse>(`/api/movies/genre?genre_id=${genreId}&page=${page}`);
-  }
-
-  async healthCheck(): Promise<{ status: string }> {
-    return this.request<{ status: string }>('/healthz');
-  }
+if (!import.meta.env.VITE_API_BASE_URL) {
+  console.warn('VITE_API_BASE_URLが環境変数に設定されていません。デフォルト値を使用します: http://localhost:8080');
 }
 
-export const apiClient = new APIClient();
-export default apiClient;
+const request = async <T>(
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<T> => {
+  const url = `${API_BASE_URL}${endpoint}`;
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+      ...options,
+    });
+
+    if (!response.ok) {
+      const errorData: APIError = await response.json();
+      throw new Error(errorData.message || `HTTP ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error('ネットワークエラーが発生しました');
+  }
+};
+
+export const getMovies = (page: number = 1): Promise<MoviesResponse> => {
+  return request<MoviesResponse>(`/api/movies?page=${page}`);
+};
+
+export const getMovieDetail = (id: number): Promise<MovieDetail> => {
+  return request<MovieDetail>(`/api/movie/${id}`);
+};
+
+export const searchMovies = (query: string, page: number = 1): Promise<MoviesResponse> => {
+  const encodedQuery = encodeURIComponent(query);
+  return request<MoviesResponse>(`/api/movies/search?query=${encodedQuery}&page=${page}`);
+};
+
+export const getMoviesByGenre = (genreId: number, page: number = 1): Promise<GenreMovieListResponse> => {
+  return request<GenreMovieListResponse>(`/api/movies/genre?genre_id=${genreId}&page=${page}`);
+};
+
+export const healthCheck = (): Promise<{ status: string }> => {
+  return request<{ status: string }>('/healthz');
+};

--- a/frontend/src/hooks/useMovies.ts
+++ b/frontend/src/hooks/useMovies.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import type { Movie, MoviesResponse } from '@/types/movie';
-import { apiClient } from '@/api';
+import { getMovies, searchMovies as searchMoviesApi } from '@/api';
 
 export function useMovies() {
   const [movies, setMovies] = useState<Movie[]>([]);
@@ -17,11 +17,11 @@ export function useMovies() {
 
     try {
       let response: MoviesResponse;
-      
+
       if (query) {
-        response = await apiClient.searchMovies(query, page);
+        response = await searchMoviesApi(query, page);
       } else {
-        response = await apiClient.getMovies(page);
+        response = await getMovies(page);
       }
 
       setMovies(response.results);


### PR DESCRIPTION
## 概要
Issue #32 の対応として、APIクライアントをclass型から関数型にリファクタリングしました。

## 変更内容

### 🔄 APIクライアントの関数型変更
- `APIClient` classを削除
- 各APIエンドポイントを個別の関数として export
  - `getMovies`
  - `getMovieDetail` 
  - `searchMovies`
  - `getMoviesByGenre`
  - `healthCheck`
- 共通の `request` 関数を作成

### 🛡️ エラーハンドリング強化
- 環境変数 `VITE_API_BASE_URL` の未設定時に警告表示
- エラーメッセージを日本語化
- フォールバック値の設定（`http://localhost:8080`）

### 🎯 useMoviesフック修正
- インポートを関数型に変更
- `import { getMovies, searchMovies as searchMoviesApi } from '@/api'`

## 効果

### ✅ Presentational/Container Pattern準拠
- Container（useMovies）: データフェッチ・状態管理
- Presentational（MovieGrid等）: UI描画のみ
- API Layer: 純粋関数（状態を持たない）

### ✅ 関数型プログラミング思想
- よりシンプルなコード
- テストしやすい構造
- 状態を持たない純粋な関数

## テスト

- [x] TypeScriptビルド成功
- [x] フロントエンドアプリケーション正常起動
- [x] 映画一覧取得機能動作確認
- [x] 映画検索機能動作確認

## Closes

Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)