### PR TITLE
feat:🎶#41ジャンル一覧取得API実装

### DIFF
--- a/backend/handlers/movies.go
+++ b/backend/handlers/movies.go
@@ -62,7 +62,7 @@ func MovieDetailHandler(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return middleware.NewInternalServerError(fmt.Sprintf("映画詳細取得失敗: %v", err))
 	}
-	
+
 	w.WriteHeader(http.StatusOK)
 	// レスポンスをJSONで返却
 	if err := json.NewEncoder(w).Encode(movieDetail); err != nil {
@@ -132,5 +132,23 @@ func ListMoviesByGenreHandler(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(result)
+	return nil
+}
+
+// ジャンル一覧取得APIハンドラー  /api/genres
+func GenresHandler(w http.ResponseWriter, r *http.Request) error {
+	w.Header().Set("Content-Type", "application/json")
+
+	// サービス層でTMDB APIからジャンル一覧を取得
+	genresResp, err := services.GetGenresFromTMDB()
+	if err != nil {
+		return middleware.NewInternalServerError(fmt.Sprintf("TMDB ジャンル一覧の取得に呼び出し失敗しました: %v", err))
+	}
+
+	w.WriteHeader(http.StatusOK)
+	// レスポンスをJSONで返却
+	if err := json.NewEncoder(w).Encode(genresResp); err != nil {
+		return middleware.NewInternalServerError(fmt.Sprintf("JSONレスポンスのエンコードに失敗しました: %v", err))
+	}
 	return nil
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -73,11 +73,14 @@ func main() {
 	// - /api/movies/search：映画検索APIエンドポイント
 	mux.HandleFunc("/api/movies/search", middleware.LoggingHandler(handlers.SearchMoviesHandler))
 
+	// - /api/genres : ジャンル一覧取得
+	mux.HandleFunc("/api/genres", middleware.LoggingHandler(handlers.GenresHandler))
+	// mux.HandleFunc("/api/genres/", middleware.LoggingHandler(handlers.GenresHandler))
+
 	// セキュリティミドルウェアを全体に適用
 	securedHandler := middleware.SecurityMiddleware(securityConfig)(mux)
 
 	// - /api/movies/popular : 人気映画ランキング（今後追加予定）
-	// - /api/movies/genre   : ジャンル別映画取得（今後追加予定）
 	//
 	// 新しいエンドポイントを追加する場合は、ここにルーティングを追記してください。
 


### PR DESCRIPTION
## 🔧 概要
ジャンル一覧を取得するAPIエンドポイント `/api/genres` を実装しました。  

## 📦 変更点
- TMDBのジャンル取得APIとの連携
- サービス層にジャンル取得ロジックを追加
- ハンドラー層でエンドポイント `/api/genres` を定義
- 単体テストを追加（正常系・エラー系）

## ✅ 動作確認
### 🔹 正常系

📎 エンドポイント：
```bash
curl http://localhost:8080/api/genres
```
🟢 想定レスポンス：
```bash
{
  "genres": [
    {"id": 28, "name": "Action"},
    {"id": 35, "name": "Comedy"},
    {"id": 18, "name": "Drama"},
  ]
}
```
### 📎 誤ったURL：

```bash
curl http://localhost:8080/api/genres/
curl http://localhost:8080/api/genre
```
🔴想定レスポンス
```bash
404 page not found
```
