### PR TITLE
feat: ✨ #35映画一覧ページの実装

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,39 +1,9 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { buttonVariants } from "@/lib/button-variants"
 
 function Button({
   className,
@@ -56,4 +26,4 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/frontend/src/lib/button-variants.ts
+++ b/frontend/src/lib/button-variants.ts
@@ -1,0 +1,32 @@
+import { cva } from "class-variance-authority"
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)

--- a/frontend/src/pages/MoviesPage.tsx
+++ b/frontend/src/pages/MoviesPage.tsx
@@ -1,4 +1,45 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMovies } from '@/hooks/useMovies';
+import { MovieGrid } from '@/components/MovieGrid';
+import { Pagination } from '@/components/Pagination';
+import type { Movie } from '@/types/movie';
+
 export function MoviesPage() {
+  const navigate = useNavigate();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [inputValue, setInputValue] = useState('');
+  const {
+    movies,
+    loading,
+    error,
+    currentPage,
+    totalPages,
+    totalResults,
+    searchMovies,
+    clearSearch,
+    goToPage,
+    refresh,
+  } = useMovies();
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (inputValue.trim()) {
+      setSearchQuery(inputValue.trim());
+      searchMovies(inputValue.trim());
+    }
+  };
+
+  const handleClearSearch = () => {
+    setInputValue('');
+    setSearchQuery('');
+    clearSearch();
+  };
+
+  const handleMovieClick = (movie: Movie) => {
+    navigate(`/movie/${movie.id}`);
+  };
+
   return (
     <div className="min-h-screen py-8">
       <div className="bg-white/95 backdrop-blur-md rounded-xl p-8 shadow-lg mb-8">
@@ -6,76 +47,73 @@ export function MoviesPage() {
           🎦 映画一覧
         </h1>
         
-        {/* 検索・フィルターセクション */}
-        <div className="space-y-6">
+        {/* 検索セクション */}
+        <form onSubmit={handleSearch} className="space-y-6">
           <div className="flex gap-4">
             <input
               type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
               placeholder="映画タイトルを入力..."
               className="flex-1 px-4 py-3 border-2 border-gray-200 rounded-full focus:border-indigo-500 focus:outline-none transition-colors"
             />
-            <button className="bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 rounded-full font-semibold transition-colors">
+            <button 
+              type="submit"
+              className="bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 rounded-full font-semibold transition-colors"
+            >
               検索
             </button>
+            {searchQuery && (
+              <button 
+                type="button"
+                onClick={handleClearSearch}
+                className="bg-gray-500 hover:bg-gray-600 text-white px-6 py-3 rounded-full font-semibold transition-colors"
+              >
+                クリア
+              </button>
+            )}
           </div>
-          
-          <div className="flex flex-wrap gap-4">
-            <select className="px-4 py-2 border-2 border-gray-200 rounded-full focus:border-indigo-500 focus:outline-none bg-white">
-              <option value="">すべてのジャンル</option>
-              <option value="28">アクション</option>
-              <option value="35">コメディ</option>
-              <option value="18">ドラマ</option>
-              <option value="27">ホラー</option>
-              <option value="10749">ロマンス</option>
-              <option value="878">SF</option>
-            </select>
-            
-            <select className="px-4 py-2 border-2 border-gray-200 rounded-full focus:border-indigo-500 focus:outline-none bg-white">
-              <option value="">すべての年代</option>
-              <option value="2024">2024年</option>
-              <option value="2023">2023年</option>
-              <option value="2022">2022年</option>
-              <option value="2021">2021年</option>
-              <option value="2020">2020年</option>
-            </select>
-            
-            <select className="px-4 py-2 border-2 border-gray-200 rounded-full focus:border-indigo-500 focus:outline-none bg-white">
-              <option value="popularity.desc">人気順</option>
-              <option value="release_date.desc">最新順</option>
-              <option value="vote_average.desc">評価順</option>
-            </select>
+        </form>
+
+        {/* 検索結果情報 */}
+        {searchQuery && (
+          <div className="mt-4 text-center text-gray-600">
+            <p>"{searchQuery}" の検索結果: {totalResults}件</p>
           </div>
-        </div>
+        )}
       </div>
+
+      {/* エラー表示 */}
+      {error && (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-8">
+          <p>エラーが発生しました: {error}</p>
+          <button 
+            onClick={refresh}
+            className="mt-2 bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded transition-colors"
+          >
+            再試行
+          </button>
+        </div>
+      )}
 
       {/* 映画一覧表示エリア */}
       <div className="bg-white/95 backdrop-blur-md rounded-xl p-8 shadow-lg">
-        <div className="text-center text-gray-600">
-          <p className="text-lg mb-4">準備中...</p>
-          <p>既存の映画一覧機能を移行予定です</p>
-        </div>
+        <MovieGrid 
+          movies={movies}
+          loading={loading}
+          onMovieClick={handleMovieClick}
+        />
       </div>
 
       {/* ページネーション */}
-      <div className="flex justify-center mt-8">
-        <div className="flex gap-2">
-          <button className="px-4 py-2 border-2 border-indigo-600 text-indigo-600 rounded hover:bg-indigo-600 hover:text-white transition-colors">
-            ‹ 前
-          </button>
-          <button className="px-4 py-2 bg-indigo-600 text-white rounded">
-            1
-          </button>
-          <button className="px-4 py-2 border-2 border-indigo-600 text-indigo-600 rounded hover:bg-indigo-600 hover:text-white transition-colors">
-            2
-          </button>
-          <button className="px-4 py-2 border-2 border-indigo-600 text-indigo-600 rounded hover:bg-indigo-600 hover:text-white transition-colors">
-            3
-          </button>
-          <button className="px-4 py-2 border-2 border-indigo-600 text-indigo-600 rounded hover:bg-indigo-600 hover:text-white transition-colors">
-            次 ›
-          </button>
-        </div>
-      </div>
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          loading={loading}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 映画一覧表示機能の実装（既存useMoviesフック活用）
- 検索機能の実装（タイトル検索、クリア機能）
- ページネーション機能の実装（Next/Previous、ページ番号）
- 映画カードクリック時の詳細ページ遷移
- buttonVariantsを別ファイルに分離してlintエラー修正

## Test plan
- [x] 映画一覧が正常に表示される
- [x] 検索機能が正常に動作する
- [x] ページネーション機能が正常に動作する
- [x] 映画カードクリック時に詳細ページに遷移する
- [x] lint・型チェックが通る（`npm run lint` コマンドで確認）