### PR TITLE
feat:🕺#38 ジャンル別ページ実装

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,4 +1,4 @@
-import type { MoviesResponse, MovieDetail, GenreMovieListResponse, APIError } from '@/types/movie';
+import type { MoviesResponse, MovieDetail, GenreMovieListResponse, APIError ,GenreListResponse} from '@/types/movie';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
 
@@ -50,6 +50,10 @@ export const searchMovies = (query: string, page: number = 1): Promise<MoviesRes
 
 export const getMoviesByGenre = (genreId: number, page: number = 1): Promise<GenreMovieListResponse> => {
   return request<GenreMovieListResponse>(`/api/movies/genre?genre_id=${genreId}&page=${page}`);
+};
+
+export const getGenres = (): Promise<{ genres: { id: number; name: string }[] }> => {
+  return request<GenreListResponse>('/api/genres');
 };
 
 export const healthCheck = (): Promise<{ status: string }> => {

--- a/frontend/src/hooks/useGenres.ts
+++ b/frontend/src/hooks/useGenres.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+import { getGenres } from '@/api/index';
+import type { Genre } from '@/types/movie';
+
+export function useGenres() {
+  const [genres, setGenres] = useState<Genre[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchGenres = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await getGenres();
+      setGenres(response.genres);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'エラーが発生しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchGenres();
+  }, []);
+
+  return {
+    genres,
+    loading,
+    error,
+    refresh: fetchGenres,
+  };
+}

--- a/frontend/src/hooks/useMoviesByGenre.ts
+++ b/frontend/src/hooks/useMoviesByGenre.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect, useRef } from 'react';
+import { getMoviesByGenre } from '@/api';
+import type { Movie, GenreMovieListResponse } from '@/types/movie';
+
+export function useMoviesByGenre(genreId: number) {
+  const [movies, setMovies] = useState<Movie[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [perPage, setPerPage] = useState(20);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalResults, setTotalResults] = useState(0);
+
+  const fetchMoviesByGenre = async (genreId: number, page: number) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response: GenreMovieListResponse = await getMoviesByGenre(genreId, page);
+      setMovies(response.results);
+      setCurrentPage(response.page);
+      setPerPage(response.per_page);
+      setTotalPages(response.total_pages);
+      setTotalResults(response.total_results);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+      setMovies([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const prevGenreRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!genreId) return;
+    const pageToFetch = prevGenreRef.current !== genreId ? 1 : currentPage;
+    prevGenreRef.current = genreId;
+    setCurrentPage(pageToFetch);
+    fetchMoviesByGenre(genreId, pageToFetch);
+  }, [genreId, currentPage]);
+
+  const goToPage = (page: number) => {
+    setCurrentPage(page);
+  };
+  
+  const refresh = () => {
+    fetchMoviesByGenre(genreId, currentPage);
+  };
+
+  return {
+    movies,
+    loading,
+    error,
+    currentPage,
+    perPage,
+    totalPages,
+    totalResults,
+    goToPage,
+    refresh,
+  };
+}

--- a/frontend/src/pages/GenrePage.tsx
+++ b/frontend/src/pages/GenrePage.tsx
@@ -1,50 +1,101 @@
-import { useParams } from 'react-router-dom';
-
-const genres: Record<string, { name: string; description: string }> = {
-  '28': { name: 'アクション', description: 'スリル満点のアクション映画' },
-  '35': { name: 'コメディ', description: '笑いあふれるコメディ映画' },
-  '18': { name: 'ドラマ', description: '心に響くドラマ映画' },
-  '27': { name: 'ホラー', description: '恐怖と緊張のホラー映画' },
-  '10749': { name: 'ロマンス', description: '愛と感動のロマンス映画' },
-  '878': { name: 'SF', description: '未来とテクノロジーのSF映画' }
-};
+import { useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { useMoviesByGenre } from "@/hooks/useMoviesByGenre";
+import { useGenres } from "@/hooks/useGenres";
+import { MovieGrid } from "@/components/MovieGrid";
+import { Pagination } from "@/components/Pagination";
+import type { Movie } from "@/types/movie";
 
 export function GenrePage() {
+  const { genres, loading: genresLoading, error: genresError } = useGenres();
+  const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
-  const genre = id ? genres[id] : null;
+
+  const genreMap = genres.reduce((acc, genre) => {
+    acc[genre.id.toString()] = genre;
+    return acc;
+  }, {} as Record<string, { id: number; name: string }>);
+  const genre = id ? genreMap[id] : null;
+
+  const { movies, loading, error, currentPage, totalPages, goToPage } =
+    useMoviesByGenre(genre ? genre.id : 0);
+  const handleMovieClick = (movie: Movie) => {
+    navigate(`/movie/${movie.id}`);
+  };
+
+  if (genresLoading) {
+    return (
+      <p className="text-center text-indigo-600 font-semibold mt-8">
+        ジャンルを読み込み中...
+      </p>
+    );
+  }
+
+  if (genresError) {
+    return (
+      <p className="text-center text-red-500 font-semibold mt-8">
+        ジャンルの取得中にエラーが発生しました: {genresError}
+      </p>
+    );
+  }
 
   return (
     <div className="min-h-screen py-8">
-      <div className="bg-white/95 backdrop-blur-md rounded-xl p-8 shadow-lg text-center mb-8">
-        <h1 className="text-3xl font-bold text-indigo-600 mb-4">
-          🏷️ {genre?.name || 'ジャンル別映画'}
+      <div className="bg-white/95 backdrop-blur-md rounded-xl p-8 shadow-lg mb-8 relative">
+        <h1 className="text-3xl font-bold text-indigo-600 text-center">
+          🏷️ {genre?.name || "ジャンル別映画"}
         </h1>
-        <p className="text-gray-600">
-          {genre?.description || '選択されたジャンルの映画一覧'}
-        </p>
+        {genres.length > 0 && (
+          <div className="absolute top-1/2 right-4 transform -translate-y-1/2">
+            <select
+              className="border border-gray-300 rounded px-4 py-2 text-gray-700"
+              value={id}
+              onChange={(e) => navigate(`/genre/${e.target.value}`)}
+            >
+              {genres.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
       </div>
-      
+
       <div className="bg-white/95 backdrop-blur-md rounded-xl p-8 shadow-lg">
         <div className="text-center text-gray-600">
-          <p className="text-lg mb-4">準備中...</p>
-          <p>ジャンル ID: {id || '未指定'}</p>
-          <p className="mt-2">ジャンル別映画一覧表示機能を実装予定です</p>
+          <p className="text-lg mb-2 font-semibold">
+            {genre?.name ? `${genre.name}映画一覧` : "ジャンル別映画一覧"}
+          </p>
+          <p className="text-sm text-gray-500 mb-4">
+            ジャンル ID: {id || "未指定"}
+          </p>
+
+          {error && (
+            <p className="text-red-500 font-semibold mb-4">
+              エラーが発生しました: {error}
+            </p>
+          )}
+          {loading && movies.length === 0 ? (
+            <p className="text-indigo-600 font-semibold">読み込み中...</p>
+          ) : (
+            <MovieGrid
+              movies={movies}
+              loading={loading}
+              onMovieClick={handleMovieClick}
+            />
+          )}
         </div>
       </div>
-      
+
       {/* ページネーション */}
       <div className="flex justify-center mt-8">
-        <div className="flex gap-2">
-          <button className="px-4 py-2 border-2 border-indigo-600 text-indigo-600 rounded hover:bg-indigo-600 hover:text-white transition-colors">
-            ‹ 前
-          </button>
-          <button className="px-4 py-2 bg-indigo-600 text-white rounded">
-            1
-          </button>
-          <button className="px-4 py-2 border-2 border-indigo-600 text-indigo-600 rounded hover:bg-indigo-600 hover:text-white transition-colors">
-            次 ›
-          </button>
-        </div>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          loading={loading}
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/MovieDetailPage.tsx
+++ b/frontend/src/pages/MovieDetailPage.tsx
@@ -1,6 +1,6 @@
-import { useParams } from 'react-router-dom';
-import { useMovieDetail } from '@/hooks/useMovieDetail';
-import { useNavigate } from 'react-router-dom';
+import { useParams } from "react-router-dom";
+import { useMovieDetail } from "@/hooks/useMovieDetail";
+import { useNavigate } from "react-router-dom";
 
 export function MovieDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -8,20 +8,32 @@ export function MovieDetailPage() {
   const { movie, loading, error } = useMovieDetail(id);
 
   if (loading) {
-    return <div className="min-h-screen flex items-center justify-center">読み込み中...</div>;
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        読み込み中...
+      </div>
+    );
   }
   if (error) {
-    return <div className="min-h-screen flex items-center justify-center">エラー: {error}</div>;
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        エラー: {error}
+      </div>
+    );
   }
   if (!movie) {
-    return <div className="min-h-screen flex items-center justify-center">映画が見つかりません</div>;
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        映画が見つかりません
+      </div>
+    );
   }
 
   return (
     <div className="min-h-screen py-8">
       <button
         className="mb-6 bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg transition-colors"
-        onClick={() => navigate('/')}
+        onClick={() => navigate("/")}
       >
         ← 戻る
       </button>
@@ -38,18 +50,57 @@ export function MovieDetailPage() {
             />
           )}
           <div className="flex-1 text-gray-700">
-            <p className="mb-2"><span className="font-semibold">原題:</span> {movie.original_title}</p>
-            <p className="mb-2"><span className="font-semibold">公開日:</span> {movie.release_date}</p>
-            <p className="mb-2"><span className="font-semibold">ジャンル:</span> {movie.genres.map(g => g.name).join(', ')}</p>
-            <p className="mb-2"><span className="font-semibold">言語:</span> {movie.original_language}</p>
-            <p className="mb-2"><span className="font-semibold">人気度:</span> {movie.popularity}</p>
-            <p className="mb-2"><span className="font-semibold">予算:</span> {movie.budget ? `${movie.budget.toLocaleString()} USD` : '不明'}</p>
-            <p className="mb-2"><span className="font-semibold">IMDB:</span> {movie.imdb_id ? (
-              <a href={`https://www.imdb.com/title/${movie.imdb_id}`} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">{movie.imdb_id}</a>
-            ) : 'なし'}</p>
-            <p className="mb-4"><span className="font-semibold">概要:</span> {movie.overview || '説明なし'}</p>
+            <p className="mb-2">
+              <span className="font-semibold">原題:</span>{" "}
+              {movie.original_title}
+            </p>
+            <p className="mb-2">
+              <span className="font-semibold">公開日:</span>{" "}
+              {movie.release_date}
+            </p>
+            <p className="mb-2">
+              <span className="font-semibold">ジャンル:</span>{" "}
+              {movie.genres.map((g) => g.name).join(", ")}
+            </p>
+            <p className="mb-2">
+              <span className="font-semibold">言語:</span>{" "}
+              {movie.original_language}
+            </p>
+            <p className="mb-2">
+              <span className="font-semibold">人気度:</span> {movie.popularity}
+            </p>
+            <p className="mb-2">
+              <span className="font-semibold">予算:</span>{" "}
+              {movie.budget ? `${movie.budget.toLocaleString()} USD` : "不明"}
+            </p>
+            <p className="mb-2">
+              <span className="font-semibold">IMDB:</span>{" "}
+              {movie.imdb_id ? (
+                <a
+                  href={`https://www.imdb.com/title/${movie.imdb_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 underline"
+                >
+                  {movie.imdb_id}
+                </a>
+              ) : (
+                "なし"
+              )}
+            </p>
+            <p className="mb-4">
+              <span className="font-semibold">概要:</span>{" "}
+              {movie.overview || "説明なし"}
+            </p>
             {movie.homepage && (
-              <a href={movie.homepage} target="_blank" rel="noopener noreferrer" className="text-indigo-600 underline">公式サイト</a>
+              <a
+                href={movie.homepage}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-indigo-600 underline"
+              >
+                公式サイト
+              </a>
             )}
           </div>
         </div>

--- a/frontend/src/types/movie.ts
+++ b/frontend/src/types/movie.ts
@@ -26,6 +26,10 @@ export interface Genre {
   name: string;
 }
 
+export interface GenreListResponse {
+  genres: Genre[];
+}
+
 export interface MoviesResponse {
   page: number;
   total_pages: number;


### PR DESCRIPTION
## 🔧 概要

ジャンル別映画ページを新規実装しました。  

---

## 📦 変更点

### 🔹 コンポーネント

- `GenrePage` コンポーネントを追加
  - `/genre/:id` に対応するルーティング
  - 選択中のジャンル名と映画一覧の表示
  - ジャンル選択用のプルダウンを追加
  - ページネーション機能を統合

### 🔹 カスタムフック

- `useMoviesByGenre` フックを追加
  - 指定されたジャンル ID に基づく映画一覧の取得
  - 現在ページ、総ページ数、取得件数などを管理
  - ジャンル変更時にはページ番号を1にリセット
  - ローディング・エラー状態を管理

- `useGenres` フックを追加（⬅️ この差分）
  - 初回マウント時に取得処理を実行
  - エラーとローディング状態も内部で管理

