### PR TITLE
feat: ジャンル一覧ページルート追加 #36

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ function App() {
         <Route path="/" element={<Layout />}>
           <Route index element={<HomePage />} />
           <Route path="movies" element={<MoviesPage />} />
+          <Route path="genre" element={<GenrePage />} />
           <Route path="search" element={<SearchPage />} />
           <Route path="movie/:id" element={<MovieDetailPage />} />
           <Route path="genre/:id" element={<GenrePage />} />

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -7,6 +7,7 @@ export function Navigation() {
   const navItems = [
     { href: '/', label: '🏠 ホーム' },
     { href: '/movies', label: '🎦 映画一覧' },
+    { href: '/genre', label: '🏷️ ジャンルから選ぶ' },
     { href: '/search', label: '🔍 検索' },
   ];
 

--- a/frontend/src/pages/GenrePage.tsx
+++ b/frontend/src/pages/GenrePage.tsx
@@ -11,14 +11,17 @@ export function GenrePage() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
 
+  // デフォルトでid=28を使用（idパラメータがない場合）
+  const genreId = id || '28';
+
   const genreMap = genres.reduce((acc, genre) => {
     acc[genre.id.toString()] = genre;
     return acc;
   }, {} as Record<string, { id: number; name: string }>);
-  const genre = id ? genreMap[id] : null;
+  const genre = genreMap[genreId] || null;
 
   const { movies, loading, error, currentPage, totalPages, goToPage } =
-    useMoviesByGenre(genre ? genre.id : 0);
+    useMoviesByGenre(genre ? genre.id : parseInt(genreId));
   const handleMovieClick = (movie: Movie) => {
     navigate(`/movie/${movie.id}`);
   };
@@ -49,7 +52,7 @@ export function GenrePage() {
           <div className="absolute top-1/2 right-4 transform -translate-y-1/2">
             <select
               className="border border-gray-300 rounded px-4 py-2 text-gray-700"
-              value={id}
+              value={genreId}
               onChange={(e) => navigate(`/genre/${e.target.value}`)}
             >
               {genres.map((g) => (
@@ -68,7 +71,7 @@ export function GenrePage() {
             {genre?.name ? `${genre.name}映画一覧` : "ジャンル別映画一覧"}
           </p>
           <p className="text-sm text-gray-500 mb-4">
-            ジャンル ID: {id || "未指定"}
+            ジャンル ID: {genreId}
           </p>
 
           {error && (


### PR DESCRIPTION
## 概要
- `/genre` ルートを追加し、ジャンル一覧ページにアクセス可能にしました
- デフォルトでid=28のジャンルが表示されます
- ナビゲーションに「ジャンルから選ぶ」メニューを追加しました

## 変更内容

### 1. ルーティング追加
- `App.tsx` に `/genre` ルートを追加
- 既存の `GenrePage` コンポーネントを活用

### 2. ナビゲーション更新
- `Navigation.tsx` に「🏷️ ジャンルから選ぶ」メニューを追加

### 3. GenrePage修正
- URLパラメータ `id` がない場合、デフォルトでid=28を使用
- セレクトボックスでジャンル切り替え可能

## 動作確認
- [x] `/genre` にアクセスしてデフォルトジャンル（id=28）が表示される
- [x] ナビゲーションの「ジャンルから選ぶ」から遷移できる  
- [x] セレクトボックスで他のジャンルに切り替えできる
- [x] 既存の `/genre/:id` ルートも正常に動作する

## 関連Issue
Closes #36