### PR TITLE
fix: ページネーションとURLクエリパラメータの同期修正

### DIFF
--- a/frontend/src/hooks/useMoviesByGenre.ts
+++ b/frontend/src/hooks/useMoviesByGenre.ts
@@ -1,15 +1,19 @@
 import { useState, useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { getMoviesByGenre } from '@/api';
 import type { Movie, GenreMovieListResponse } from '@/types/movie';
 
 export function useMoviesByGenre(genreId: number) {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [movies, setMovies] = useState<Movie[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [currentPage, setCurrentPage] = useState(1);
   const [perPage, setPerPage] = useState(20);
   const [totalPages, setTotalPages] = useState(0);
   const [totalResults, setTotalResults] = useState(0);
+  
+  // URLクエリパラメータから現在のページを取得
+  const currentPage = parseInt(searchParams.get('page') || '1');
 
   const fetchMoviesByGenre = async (genreId: number, page: number) => {
     setLoading(true);
@@ -18,7 +22,6 @@ export function useMoviesByGenre(genreId: number) {
     try {
       const response: GenreMovieListResponse = await getMoviesByGenre(genreId, page);
       setMovies(response.results);
-      setCurrentPage(response.page);
       setPerPage(response.per_page);
       setTotalPages(response.total_pages);
       setTotalResults(response.total_results);
@@ -33,14 +36,31 @@ export function useMoviesByGenre(genreId: number) {
   const prevGenreRef = useRef<number | null>(null);
   useEffect(() => {
     if (!genreId) return;
-    const pageToFetch = prevGenreRef.current !== genreId ? 1 : currentPage;
-    prevGenreRef.current = genreId;
-    setCurrentPage(pageToFetch);
-    fetchMoviesByGenre(genreId, pageToFetch);
-  }, [genreId, currentPage]);
+    
+    // ジャンルが変わった場合はページを1にリセット
+    if (prevGenreRef.current !== genreId) {
+      prevGenreRef.current = genreId;
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set('page', '1');
+      setSearchParams(newParams, { replace: true });
+      return;
+    }
+    
+    // 初回ロード時にページ番号がURLにない場合は page=1 を設定
+    if (!searchParams.has('page')) {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set('page', '1');
+      setSearchParams(newParams, { replace: true });
+    } else {
+      // URLパラメータがある場合は映画を取得
+      fetchMoviesByGenre(genreId, currentPage);
+    }
+  }, [genreId, searchParams]);
 
   const goToPage = (page: number) => {
-    setCurrentPage(page);
+    const newParams = new URLSearchParams(searchParams);
+    newParams.set('page', page.toString());
+    setSearchParams(newParams);
   };
   
   const refresh = () => {

--- a/frontend/src/pages/MoviesPage.tsx
+++ b/frontend/src/pages/MoviesPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMovies } from '@/hooks/useMovies';
 import { MovieGrid } from '@/components/MovieGrid';
@@ -7,7 +7,6 @@ import type { Movie } from '@/types/movie';
 
 export function MoviesPage() {
   const navigate = useNavigate();
-  const [searchQuery, setSearchQuery] = useState('');
   const [inputValue, setInputValue] = useState('');
   const {
     movies,
@@ -16,23 +15,27 @@ export function MoviesPage() {
     currentPage,
     totalPages,
     totalResults,
+    searchQuery,
     searchMovies,
     clearSearch,
     goToPage,
     refresh,
   } = useMovies();
 
+  // URLから検索クエリが変わった時に入力フィールドを同期
+  useEffect(() => {
+    setInputValue(searchQuery);
+  }, [searchQuery]);
+
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (inputValue.trim()) {
-      setSearchQuery(inputValue.trim());
       searchMovies(inputValue.trim());
     }
   };
 
   const handleClearSearch = () => {
     setInputValue('');
-    setSearchQuery('');
     clearSearch();
   };
 


### PR DESCRIPTION
## 🐛 問題
PR #52に関連して、ページネーション機能で以下の問題が発生していました：

1. **初回アクセス時に映画が表示されない**
   - `/movies` にアクセスすると「映画が見つかりませんでした」と表示
   - useEffect で return してしまい fetchMovies が呼ばれない

2. **URLクエリパラメータが不完全**
   - 初回は `/movies` のまま
   - 2ページ目から `/movies?page=2` になる

## 🛠 修正内容

### 1. useEffect 依存配列の修正
**Before:**
```typescript
useEffect(() => {
  // 処理
}, [currentPage, searchQuery]);
```

**After:**
```typescript
useEffect(() => {
  // 処理  
}, [searchParams]);
```

### 2. 初回ロード時の処理改善
- URLパラメータがない場合: `page=1` を設定
- URLパラメータがある場合: APIを呼び出し

### 3. API呼び出しタイミングの最適化
- URL同期とAPI呼び出しを適切に分離
- 無限ループやタイミング問題を解決

## 📝 変更ファイル

### `hooks/useMovies.ts`
- useEffect依存配列を `[searchParams]` に変更
- 初回ロード時の処理フローを改善

### `hooks/useMoviesByGenre.ts`  
- 同様にURL同期とAPI呼び出しを分離
- ジャンル変更時の処理も改善

## 🎯 修正後の動作

### URL同期
- ✅ `/movies` → `/movies?page=1` (初回アクセス時)
- ✅ `/movies?page=2` (ページ変更時)  
- ✅ `/movies?query=batman&page=1` (検索時)

### 映画表示
- ✅ 初回アクセス時に映画一覧が正常表示
- ✅ ページネーション動作
- ✅ ブラウザ戻る/進むボタン対応

## 🧪 テスト

### 手動テスト項目
- [x] `/movies` 初回アクセス → 映画一覧表示 & URL が `/movies?page=1`
- [x] ページネーション → URL が適切に更新される
- [x] ブラウザ戻るボタン → 状態が正しく復元される
- [x] `/genre` と `/genre/28` でも同様に動作
- [x] 検索機能も URL と同期

### ビルドテスト
```bash
✓ npm run build - 成功
✓ TypeScript コンパイル - エラーなし
```

## 🔗 関連

- この修正により PR #52 で指摘された問題が解決されます
- URL とアプリケーション状態の一貫性が保たれます
- ユーザーは現在のページを URL で確認できるようになります

Fixes: ページネーション URL 同期問題