### PR TITLE
hotfix: Docker環境でのGO_ENV設定を.envファイルから読み込むよう修正

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,8 +35,6 @@ RUN mkdir -p logs
 # ポート8080を公開
 EXPOSE 8080
 
-# 本番環境用の環境変数を設定
-ENV GO_ENV=production
 
 # アプリケーションを実行
 CMD ["./main"]

--- a/backend/main.go
+++ b/backend/main.go
@@ -13,9 +13,9 @@ import (
 )
 
 func main() {
-	// .env読み込み
+	// .env読み込み（ファイルが存在しない場合は無視）
 	if err := godotenv.Load(".env"); err != nil {
-		log.Fatalf(".envファイルを設定してください: %v", err)
+		log.Printf(".envファイルが見つかりません（環境変数が設定されていれば正常動作します）: %v", err)
 	}
 
 	// logsディレクトリ自動作成


### PR DESCRIPTION
## Summary
- DockerfileからGO_ENV=productionのハードコーディングを削除
- main.goで.envファイルが見つからない場合の致命的エラーを警告に変更
- Docker環境でもローカル環境でも同じ.env設定を使用可能に

## 修正内容
1. **backend/Dockerfile**: `ENV GO_ENV=production`を削除
2. **backend/main.go**: `.env`ファイルが見つからない場合は`log.Fatalf`から`log.Printf`に変更

## 問題の背景
- Docker環境とローカル環境でGO_ENVの設定が異なり、セキュリティミドルウェアの動作に差異が発生
- Docker環境では`.env`ファイルがコンテナ内にコピーされないため、アプリケーションが起動しない

## 修正後の動作
- Docker環境: `compose.yml`の`env_file`設定により`.env`ファイルの環境変数を使用
- ローカル環境: 直接`.env`ファイルを読み込み
- 両方とも同じ環境変数を参照するため、動作が統一される

## Test plan
- [x] Docker環境でバックエンドコンテナが正常起動することを確認
- [x] API エンドポイント（/healthz, /api/genres）が正常に動作することを確認
- [x] ローカル環境でも引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)